### PR TITLE
Update Gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,12 +1,14 @@
 source "https://rubygems.org"
 
-gem "activerecord", '~> 6.1'
+gem "activerecord", '~> 7.0'
 gem "json", "~> 1.8", ">= 1.8.5"
+gem "logger"
+gem "ostruct"
 gem "pry"
 gem "rake"
 gem "sqlite3", "~> 1.4"
 
 group :test do
-  gem "database_cleaner"
+  gem "database_cleaner", "~> 2.0"
   gem "rspec"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,64 +1,91 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (6.1.4)
-      activesupport (= 6.1.4)
-    activerecord (6.1.4)
-      activemodel (= 6.1.4)
-      activesupport (= 6.1.4)
-    activesupport (6.1.4)
-      concurrent-ruby (~> 1.0, >= 1.0.2)
+    activemodel (7.2.2.1)
+      activesupport (= 7.2.2.1)
+    activerecord (7.2.2.1)
+      activemodel (= 7.2.2.1)
+      activesupport (= 7.2.2.1)
+      timeout (>= 0.4.0)
+    activesupport (7.2.2.1)
+      base64
+      benchmark (>= 0.3)
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.3.1)
+      connection_pool (>= 2.2.5)
+      drb
       i18n (>= 1.6, < 2)
+      logger (>= 1.4.2)
       minitest (>= 5.1)
-      tzinfo (~> 2.0)
-      zeitwerk (~> 2.3)
+      securerandom (>= 0.3)
+      tzinfo (~> 2.0, >= 2.0.5)
+    base64 (0.3.0)
+    benchmark (0.4.1)
+    bigdecimal (3.2.2)
     coderay (1.1.3)
-    concurrent-ruby (1.1.9)
-    database_cleaner (2.0.1)
-      database_cleaner-active_record (~> 2.0.0)
-    database_cleaner-active_record (2.0.1)
+    concurrent-ruby (1.3.5)
+    connection_pool (2.5.3)
+    database_cleaner (2.1.0)
+      database_cleaner-active_record (>= 2, < 3)
+    database_cleaner-active_record (2.2.1)
       activerecord (>= 5.a)
       database_cleaner-core (~> 2.0.0)
     database_cleaner-core (2.0.1)
-    diff-lcs (1.4.4)
-    i18n (1.8.10)
+    diff-lcs (1.6.2)
+    drb (2.2.3)
+    i18n (1.14.7)
       concurrent-ruby (~> 1.0)
     json (1.8.6)
-    method_source (1.0.0)
-    minitest (5.14.4)
-    pry (0.14.1)
+    logger (1.7.0)
+    method_source (1.1.0)
+    minitest (5.25.5)
+    ostruct (0.6.3)
+    pry (0.15.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    rake (13.0.6)
-    rspec (3.10.0)
-      rspec-core (~> 3.10.0)
-      rspec-expectations (~> 3.10.0)
-      rspec-mocks (~> 3.10.0)
-    rspec-core (3.10.1)
-      rspec-support (~> 3.10.0)
-    rspec-expectations (3.10.1)
+    rake (13.3.0)
+    rspec (3.13.1)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.5)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.5)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.10.0)
-    rspec-mocks (3.10.2)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.5)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.10.0)
-    rspec-support (3.10.2)
-    sqlite3 (1.4.2)
-    tzinfo (2.0.4)
+      rspec-support (~> 3.13.0)
+    rspec-support (3.13.4)
+    securerandom (0.4.1)
+    sqlite3 (1.7.3-aarch64-linux)
+    sqlite3 (1.7.3-arm-linux)
+    sqlite3 (1.7.3-arm64-darwin)
+    sqlite3 (1.7.3-x86-linux)
+    sqlite3 (1.7.3-x86_64-darwin)
+    sqlite3 (1.7.3-x86_64-linux)
+    timeout (0.4.3)
+    tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    zeitwerk (2.4.2)
 
 PLATFORMS
-  x86_64-darwin-19
+  aarch64-linux
+  arm-linux
+  arm64-darwin
+  x86-linux
+  x86_64-darwin
+  x86_64-linux
 
 DEPENDENCIES
-  activerecord (~> 6.1)
-  database_cleaner
+  activerecord (~> 7.0)
+  database_cleaner (~> 2.0)
   json (~> 1.8, >= 1.8.5)
+  logger
+  ostruct
   pry
   rake
   rspec
   sqlite3 (~> 1.4)
 
 BUNDLED WITH
-   2.2.23
+   2.7.1


### PR DESCRIPTION
This pull request updates dependencies in the `Gemfile` to use more recent versions and adds new gems to support additional functionality.

Dependency updates:

* Updated the `activerecord` gem from version `~> 6.1` to `~> 7.0` to use the latest features and improvements of Active Record.
* Updated the `database_cleaner` gem in the test group to version `~> 2.0` for compatibility and enhanced functionality.

New dependencies:

* Added the `logger` gem for logging capabilities.
* Added the `ostruct` gem to enable the use of OpenStruct objects.